### PR TITLE
Fix USWDS favicon links

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -50,23 +50,11 @@
     <meta property="og:url" content="{{ site.url }}{{ page.url }}">
     {% endif %}
 
-    <!-- 128x128 -->
     <link rel="shortcut icon" type="image/ico" href="{{ site.baseurl }}/assets/img/favicons/favicon.ico">
-    <link rel="icon" type="image/png" href="{{ site.baseurl }}/assets/img/favicons/favicon.png">
-
-    <!-- 192x192, as recommended for Android
-    http://updates.html5rocks.com/2014/11/Support-for-theme-color-in-Chrome-39-for-Android
-    -->
-    <link rel="icon" type="image/png" sizes="192x192" href="{{ site.baseurl }}/assets/img/favicons/favicon-192.png">
-
-    <!-- 57x57 (precomposed) for iPhone 3GS, pre-2011 iPod Touch and older Android devices -->
-    <link rel="apple-touch-icon-precomposed" href="{{ site.baseurl }}/assets/img/favicons/favicon-57.png">
-    <!-- 72x72 (precomposed) for 1st generation iPad, iPad 2 and iPad mini -->
-    <link rel="apple-touch-icon-precomposed" sizes="72x72" href="{{ site.baseurl }}/assets/img/favicons/favicon-72.png">
-    <!-- 114x114 (precomposed) for iPhone 4, 4S, 5 and post-2011 iPod Touch -->
-    <link rel="apple-touch-icon-precomposed" sizes="114x114" href="{{ site.baseurl }}/assets/img/favicons/favicon-114.png">
-    <!-- 144x144 (precomposed) for iPad 3rd and 4th generation -->
-    <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ site.baseurl }}/assets/img/favicons/favicon-144.png">
+    <link rel="manifest" href="{{ site.baseurl }}/assets/img/favicons/manifest.json">
+    <link rel="apple-touch-icon" sizes="180x180" href="{{ site.baseurl }}/assets/img/favicons/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" href="{{ site.baseurl }}/assets/img/favicons/favicon-16x16.png" sizes="16x16" />
+    <link rel="icon" type="image/png" href="{{ site.baseurl }}/assets/img/favicons/favicon-32x32.png" sizes="32x32" />
 
     <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/styles.css">
     <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/main.css">


### PR DESCRIPTION
Some of the links are referencing USWDS style guide assets, which results in Firefox showing the USWDS icon

![image](https://user-images.githubusercontent.com/1430443/108384343-47ff9300-71d0-11eb-846b-baf75b395948.png)

These changes point the links to the identity-style-guide versions (https://github.com/18F/identity-style-guide/tree/main/src/img/favicons)
